### PR TITLE
Update: Use the dispatch job parameters for os and phpVersion only wen running a dispatch job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,21 +2,22 @@ name: Build
 
 on:
   workflow_dispatch:
-      inputs:
-        os:
-          description: 'The operating system to use when triggering the job'
-          required: false
-          default: 'ubuntu-22.04'
-        phpVersion:
-          description: 'The php version to use when triggering the job'
-          required: false
-          default: '8.1'
+    inputs:
+      os:
+        description: 'The operating system to use when triggering the job'
+        required: false
+        default: 'ubuntu-22.04'
+      phpVersion:
+        description: 'The php version to use when triggering the job'
+        required: false
+        default: '8.1'
   pull_request:
     branches:
       - 'main'
 
 jobs:
   test:
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -25,6 +26,14 @@ jobs:
         exclude:
           - os: ubuntu-22.04
             php: 5.6
+
+  dispatch-test:
+    if: github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ inputs.os }}
+        php: ${{ inputs.phpVersion }}
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Update: Use the dispatch job parameters for os and phpVersion only wen running a dispatch job
For any CI job triggered from a PR, we should use the existing logic any execute using all the versions specified in the matrix. 